### PR TITLE
Improve HF integration

### DIFF
--- a/model/flow_estimation.py
+++ b/model/flow_estimation.py
@@ -6,6 +6,8 @@ import random
 from .warplayer import warp
 from .refine import *
 
+from huggingface_hub import PyTorchModelHubMixin
+
 def conv(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
     return nn.Sequential(
         nn.Conv2d(in_planes, out_planes, kernel_size=kernel_size, stride=stride,
@@ -76,7 +78,7 @@ class IFBlock(nn.Module):
         mask = tmp[:, 4:5]
         return flow, mask
     
-class MultiScaleFlow(nn.Module):
+class MultiScaleFlow(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/MCG-NJU/VFIMamba", pipeline_tag="video-frame-interpolation", license="apache-2.0"):
     def __init__(self, backbone, **kargs):
         super(MultiScaleFlow, self).__init__()
         self.flow_num_stage = len(kargs['hidden_dims'])


### PR DESCRIPTION
Hi @GuozhenZhang1999 and team,

Thanks for this nice work! I see the [checkpoints](https://huggingface.co/MCG-NJU/VFIMamba) are already available on the hub which is nice to see. This PR aims to improve the HF integration, as we usually recommend to store each checkpoint in a separate, dedicated model repo. This way, downloads also work for your models.

I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can 

* automatically load the model using `from_pretrained` (and push it using `push_to_hub`)
* track download numbers for your models (similar to models in the Transformers library)
* have nice model cards on a per-model basis along with tags (so that people find them when filtering https://hf.co/models) => we could collaborate on adding a dedicated "video-frame-interpolation" tag
* perhaps most importantly, leverage `safetensors` for the weights in favor of pickle. 

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from model.flow_estimation import MultiScaleFlow

# instantiate model
model = MultiScaleFlow(...)

# equip model with weights
model.load_state_dict(...)

# push to hub
model.push_to_hub("MCG-NJU/vfi-mamba")

# reload
model = MultiScaleFlow.from_pretrained("MCG-NJU/vfi-mamba")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. Checkpoints could be pushed to https://huggingface.co/MCG-NJU.

Would you be interested in this integration?

Kind regards,

Niels

## Note

Please don't merge this PR before pushing the model to the hub :)